### PR TITLE
Removes "localhost" from Base Gateway URL input field

### DIFF
--- a/app/code/community/Oxipay/Oxipayments/etc/config.xml
+++ b/app/code/community/Oxipay/Oxipayments/etc/config.xml
@@ -52,7 +52,7 @@
                 <title>Oxipay</title>
                 <allowspecific>0</allowspecific>
                 <payment_action>sale</payment_action>
-                <gateway_base_url>http://localhost:60343</gateway_base_url>
+                <gateway_base_url>https://secure.oxipay.com.au/</gateway_base_url>
                 <gateway_checkout_url>Checkout/Process?platform=default</gateway_checkout_url>
                 <merchant_number>30166666</merchant_number>
                 <api_key>TEST</api_key>


### PR DESCRIPTION
The code in master has localhost as Base Gateway URL.
I have resolved this and made it point to the secure site.